### PR TITLE
Implement non-combat skill system with local dice rolling

### DIFF
--- a/data/player_template.json
+++ b/data/player_template.json
@@ -76,12 +76,12 @@ player_data_str = """
 player_data = json.loads(player_data_str)
 
 # Update the 'skills' field
-player_data["skills"] = ["arcana", "history", "investigation", "perception", "insight", "medicine"]
+player_data["skills"] = ["arcana", "history", "investigation", "perception", "insight", "medicine", "lockpicking", "persuasion", "stealth"]
 
 # Update the 'proficiencies.skills' field
 if "proficiencies" not in player_data:
     player_data["proficiencies"] = {}
-player_data["proficiencies"]["skills"] = ["arcana", "history", "insight", "investigation", "medicine"]
+player_data["proficiencies"]["skills"] = ["arcana", "history", "insight", "investigation", "medicine", "lockpicking", "persuasion", "stealth"]
 
 # Serialize back to JSON with pretty print
 output_json = json.dumps(player_data, indent=2)

--- a/utils.py
+++ b/utils.py
@@ -6,6 +6,7 @@ SKILL_ABILITY_MAP = {
     "athletics": "strength",
     "acrobatics": "dexterity",
     "slight_of_hand": "dexterity",
+    "lockpicking": "dexterity",
     "stealth": "dexterity",
     "arcana": "intelligence",
     "history": "intelligence",
@@ -37,16 +38,29 @@ ABILITY_ABBREVIATIONS = {
     "charisma": "CHA",
 }
 
-def roll_dice(sides: int) -> int:
+def roll_dice(sides: int, num_dice: int = 1) -> int:
     """
-    Simulates rolling a single die with a given number of sides.
+    Simulates rolling one or more dice with a specified number of sides.
+
     Args:
-        sides: The number of sides on the die (e.g., 6 for a d6, 20 for a d20).
+        sides: The number of sides on each die (e.g., 6 for a d6).
+        num_dice: The number of dice to roll. Defaults to 1.
+
     Returns:
-        A random integer between 1 and `sides` (inclusive).
+        The sum of the rolls from all dice.
+
     Raises:
-        ValueError: if sides is less than 1.
+        TypeError: If sides or num_dice are not integers.
+        ValueError: If sides or num_dice are not positive.
     """
-    if sides < 1:
-        raise ValueError("Number of sides must be at least 1.")
-    return random.randint(1, sides)
+    if not isinstance(sides, int) or not isinstance(num_dice, int):
+        raise TypeError("Sides and num_dice must be integers.")
+    if sides <= 0:
+        raise ValueError("Number of sides must be positive.")
+    if num_dice <= 0:
+        raise ValueError("Number of dice to roll must be positive.")
+
+    total_roll = 0
+    for _ in range(num_dice):
+        total_roll += random.randint(1, sides)
+    return total_roll


### PR DESCRIPTION
This commit introduces a system for you to use non-combat skills such as lockpicking, persuasion, and stealth.

Key changes:
- Added 'lockpicking', 'persuasion', and 'stealth' to player data and skill mappings.
- Enhanced the `Player` class in `game_state.py`:
    - Modified constructor to accept comprehensive player data including skills, proficiencies, and ability scores.
    - Added `get_ability_modifier()` to calculate ability modifiers.
    - Added `perform_skill_check()` to handle d20 rolls, apply ability and proficiency bonuses, and determine success against a DC.
- Updated `main.py`:
    - Player instantiation now uses the new data-driven constructor.
    - Implemented command parsing (e.g., "use lockpicking on chest (DC 15)") for you to initiate skill checks.
    - Skill check attempts, dice roll breakdowns, and outcomes are reported to the DM.
- Refactored dice rolling to use a single `roll_dice` function from `utils.py`.
- Added unit tests for `get_ability_modifier` and `perform_skill_check` in `tests/test_skills.py`, ensuring the core logic is validated.

The system now allows you to attempt various non-combat actions, with success determined locally and results communicated to the DM for narrative development.