### PR TITLE
feat: Implement comprehensive Faction system

### DIFF
--- a/data/Factions/crimson_hand.json
+++ b/data/Factions/crimson_hand.json
@@ -1,0 +1,28 @@
+{
+    "id": "crimson_hand",
+    "name": "The Crimson Hand",
+    "description": "A shadowy organization seeking power through forbidden artifacts and manipulation.",
+    "goals": "Acquire powerful artifacts, destabilize regional powers, and establish their own dominion.",
+    "relationships": {
+        "verdant_wardens": "enemy",
+        "merchants_guild": "neutral"
+    },
+    "members": ["npc_malakor_shadowclaw"],
+    "rag_data": {
+        "history": "The Crimson Hand emerged from the ashes of a fallen empire, its founders vowing to reclaim lost power by any means necessary. They operate in secret, their agents infiltrating various levels of society.",
+        "detailed_goals": "They actively seek out items of immense magical power, often plundering ancient sites or manipulating individuals to acquire them. They believe true strength lies in controlling these relics. They aim to sow discord among existing power structures to create opportunities for their own ascent.",
+        "key_figures": [
+            {
+                "name": "Malakor Shadowclaw",
+                "role": "Grand Master",
+                "description": "A charismatic but ruthless leader, whose origins are shrouded in mystery. (Assumes npc_malakor_shadowclaw is a valid NPC ID)"
+            },
+            {
+                "name": "Seraphina Vane",
+                "role": "Chief Infiltrator",
+                "description": "Master of disguise and espionage."
+            }
+        ],
+        "rumored_hideouts": "Secret chambers beneath major cities, forgotten dungeons."
+    }
+}

--- a/data/Factions/merchants_guild.json
+++ b/data/Factions/merchants_guild.json
@@ -1,0 +1,23 @@
+{
+    "id": "merchants_guild",
+    "name": "The Merchants' Guild",
+    "description": "A powerful consortium of traders, artisans, and financiers.",
+    "goals": "Expand trade routes, protect commercial interests, and accumulate wealth.",
+    "relationships": {
+        "crimson_hand": "neutral",
+        "verdant_wardens": "neutral"
+    },
+    "members": ["npc_jane_copperfield"],
+    "rag_data": {
+        "history": "Founded by a group of enterprising merchants, the Guild quickly grew into a significant economic force, standardizing trade practices and funding expeditions.",
+        "detailed_goals": "The Guild aims to control key markets and resources. They lobby local lords for favorable trade agreements, fund infrastructure projects like roads and bridges, and sometimes hire mercenaries to protect their caravans. They are generally pragmatic but can be ruthless when their profits are threatened.",
+        "key_figures": [
+            {
+                "name": "Jane Copperfield",
+                "role": "Guildmaster",
+                "description": "A shrewd and influential businesswoman, known for her negotiation skills. (Assumes 'npc_merchant_jane' can be used or a new NPC 'npc_jane_copperfield' is created)"
+            }
+        ],
+        "headquarters": "The Grand Exchange in the capital city."
+    }
+}

--- a/data/Factions/verdant_wardens.json
+++ b/data/Factions/verdant_wardens.json
@@ -1,0 +1,27 @@
+{
+    "id": "verdant_wardens",
+    "name": "The Verdant Wardens",
+    "description": "Guardians of the ancient forests and natural balance.",
+    "goals": "Protect the wilderness, preserve ancient knowledge, and guide lost travelers.",
+    "relationships": {
+        "crimson_hand": "enemy"
+    },
+    "members": ["npc_theron_ashwood"],
+    "rag_data": {
+        "history": "The Verdant Wardens were formed centuries ago after the Great Blight threatened to consume all life. They are a reclusive group, deeply connected to the spirits of nature.",
+        "detailed_goals": "Their primary goal is to prevent another Blight. They also seek to restore defiled lands, study the flora and fauna to unlock nature's secrets, and occasionally assist settlements that live in harmony with nature. They are wary of unchecked industrial expansion.",
+        "key_figures": [
+            {
+                "name": "Theron Ashwood",
+                "role": "Elder Warden",
+                "description": "A wise and ancient elf, leader of the Wardens. (Assumes npc_theron_ashwood is a valid NPC ID)"
+            },
+            {
+                "name": "Lyra Meadowlight",
+                "role": "Master Herbalist",
+                "description": "Expert in potions and natural remedies."
+            }
+        ],
+        "base_of_operations": "The Sunken Grove, a hidden sanctuary deep within the Eldoria Forest."
+    }
+}

--- a/factions.py
+++ b/factions.py
@@ -1,0 +1,16 @@
+from typing import Optional, Dict, List
+
+class Faction:
+    def __init__(self,
+                 id: str,
+                 name: str,
+                 description: str,
+                 goals: str,
+                 relationships: Dict[str, str],
+                 members: Optional[List[str]] = None):
+        self.id: str = id
+        self.name: str = name
+        self.description: str = description
+        self.goals: str = goals
+        self.relationships: Dict[str, str] = relationships
+        self.members: List[str] = members if members is not None else []

--- a/quests.py
+++ b/quests.py
@@ -117,3 +117,44 @@ ALL_QUESTS = {
     q002.id: q002,
     q003.id: q003
 }
+
+# Quest for Verdant Wardens
+q_verdant_wardens_aid = Quest(
+    id="q_verdant_wardens_aid",
+    title="Whispers of Decay",
+    description="Theron Ashwood of the Verdant Wardens has sensed a growing corruption in the Whisperwood. He seeks an outsider's help to investigate a defiled grove and recover a sacred seed before its power is twisted for dark purposes.",
+    stages=[
+        {
+            "stage_id": "s1_speak_theron",
+            "description": "Speak with Theron Ashwood at the Sunken Grove to learn more about the corruption.",
+            "completion_condition": "dialogue_theron_vw_quest_start_complete",
+            "next_stage_id": "s2_investigate_grove",
+            "status_description": "Theron has asked you to investigate the Defiled Grove and retrieve a stolen sacred seed."
+        },
+        {
+            "stage_id": "s2_investigate_grove",
+            "description": "Travel to the Defiled Grove, overcome any corrupted guardians, and find the Stolen Sunseed.",
+            "completion_condition": "has_item:stolen_sunseed;defeated:corrupted_grove_guardian",
+            "next_stage_id": "s3_return_seed",
+            "status_description": "You have recovered the Stolen Sunseed from the Defiled Grove."
+        },
+        {
+            "stage_id": "s3_return_seed",
+            "description": "Return the Stolen Sunseed to Theron Ashwood.",
+            "completion_condition": "delivered_stolen_sunseed_to_theron",
+            "next_stage_id": None,
+            "status_description": "You returned the Stolen Sunseed to Theron. The Verdant Wardens are grateful."
+        }
+    ],
+    optional_objectives=[],
+    rewards={
+        'xp': 150,
+        'items': ['item_wardens_healing_draught'],
+        'currency': {'silver': 100},
+        'faction_rep_changes': [ # New reward type
+            {"faction_id": "verdant_wardens", "amount": 25}
+        ]
+    }
+)
+
+ALL_QUESTS[q_verdant_wardens_aid.id] = q_verdant_wardens_aid

--- a/tests/test_factions.py
+++ b/tests/test_factions.py
@@ -1,0 +1,152 @@
+import unittest
+from game_state import GameState, Player, Item # Assuming Item is needed for inventory if quests give items
+from factions import Faction
+from quests import Quest, ALL_QUESTS # To get the test quest
+import logging
+
+# Suppress most logging output during tests for cleaner results, unless specifically testing logging.
+# logging.disable(logging.CRITICAL) # Option: Or set to a higher level like ERROR
+
+class TestFactions(unittest.TestCase):
+
+    def setUp(self):
+        # Basic player data for initializing a Player instance
+        self.player_data = {
+            "id": "test_player", "name": "Test Player", "max_hp": 100,
+            "combat_stats": {}, "base_damage_dice": "1d4",
+            "faction_reputations": {}, "inventory": [], "equipment": {}
+        }
+        self.player = Player(self.player_data)
+
+        # Initialize GameState with the player
+        self.game_state = GameState(player_character=self.player)
+
+        # Define some factions for testing
+        self.faction1_data = {
+            "id": "wardens", "name": "Forest Wardens", "description": "Protectors of the woods.",
+            "goals": "Guard nature.", "relationships": {"hand": "enemy"}, "members": ["npc1"]
+        }
+        self.faction2_data = {
+            "id": "hand", "name": "Shadow Hand", "description": "Seekers of dark power.",
+            "goals": "Gain power.", "relationships": {"wardens": "enemy"}, "members": ["npc2"]
+        }
+        self.faction1 = Faction(**self.faction1_data)
+        self.faction2 = Faction(**self.faction2_data)
+
+        # Add factions to game_state for some tests
+        self.game_state.factions[self.faction1.id] = self.faction1
+        self.game_state.factions[self.faction2.id] = self.faction2
+
+        # Ensure the test quest q_verdant_wardens_aid is in ALL_QUESTS
+        # For this test, we'll use its actual ID 'q_verdant_wardens_aid'
+        # and assume its structure matches what was defined, especially the rewards.
+        self.test_quest_id = "q_verdant_wardens_aid"
+        if self.test_quest_id not in ALL_QUESTS:
+            # Fallback: Define a minimal quest for testing if not found (though it should be)
+            ALL_QUESTS[self.test_quest_id] = Quest(
+                id=self.test_quest_id, title="Test Aid Wardens", description="Help them.",
+                stages=[{"stage_id": "s1", "description": "Do something.", "completion_condition": "true", "next_stage_id": None}],
+                optional_objectives=[],
+                rewards={
+                    'xp': 10,
+                    'faction_rep_changes': [{"faction_id": "verdant_wardens", "amount": 25}]
+                }
+            )
+        self.verdant_wardens_id = "verdant_wardens" # Actual ID from faction data files
+         # Add the actual Verdant Wardens faction if not already for the quest test
+        if self.verdant_wardens_id not in self.game_state.factions:
+             self.game_state.factions[self.verdant_wardens_id] = Faction(id=self.verdant_wardens_id, name="The Verdant Wardens", description="", goals="", relationships={})
+
+
+    def test_faction_creation(self):
+        self.assertEqual(self.faction1.name, "Forest Wardens")
+        self.assertEqual(self.faction1.id, "wardens")
+        self.assertEqual(self.faction1.relationships, {"hand": "enemy"})
+        self.assertIsNotNone(Faction(id="test", name="Test F", description="", goals="", relationships={}, members=[]))
+        self.assertIsNotNone(Faction(id="test2", name="Test F2", description="", goals="", relationships={})) # Test optional members
+
+    def test_add_faction_to_game_state(self):
+        self.assertIn("wardens", self.game_state.factions)
+        self.assertEqual(self.game_state.factions["wardens"].name, "Forest Wardens")
+
+    def test_player_initial_faction_reputation(self):
+        self.assertEqual(self.player.faction_reputations, {})
+
+    def test_change_faction_reputation_basic(self):
+        # Using faction1 ("wardens") which is in self.game_state.factions
+        self.player.change_faction_reputation("wardens", 10, self.game_state)
+        self.assertEqual(self.player.faction_reputations.get("wardens"), 10)
+
+        self.player.change_faction_reputation("wardens", -5, self.game_state)
+        self.assertEqual(self.player.faction_reputations.get("wardens"), 5)
+
+    def test_change_faction_reputation_clamping(self):
+        # Using faction2 ("hand") which is in self.game_state.factions
+        self.player.change_faction_reputation("hand", 150, self.game_state)
+        self.assertEqual(self.player.faction_reputations.get("hand"), 100) # Should clamp to +100
+
+        self.player.change_faction_reputation("hand", -50, self.game_state) # From 100 to 50
+        self.assertEqual(self.player.faction_reputations.get("hand"), 50)
+
+        self.player.change_faction_reputation("hand", -200, self.game_state) # From 50, try to go to -150
+        self.assertEqual(self.player.faction_reputations.get("hand"), -100) # Should clamp to -100
+
+        # Test starting from 0 and going very low
+        self.player.change_faction_reputation("new_faction_test", -1000, self.game_state)
+        # Need to add "new_faction_test" to game_state.factions for name lookup in change_faction_reputation
+        self.game_state.factions["new_faction_test"] = Faction(id="new_faction_test", name="New Faction", description="", goals="", relationships={})
+        self.assertEqual(self.player.faction_reputations.get("new_faction_test"), -100)
+
+
+    def test_change_faction_reputation_unknown_faction_id_for_message(self):
+        # Test that it doesn't crash if faction_id for message is not in game_state.factions
+        # The change_faction_reputation method should use a default name like "Unknown Faction"
+        # We're mostly checking for no exceptions here.
+        # The actual reputation change should still occur.
+        initial_rep = self.player.faction_reputations.get("non_existent_faction", 0)
+        try:
+            self.player.change_faction_reputation("non_existent_faction", 10, self.game_state)
+            self.assertEqual(self.player.faction_reputations.get("non_existent_faction"), initial_rep + 10)
+        except Exception as e:
+            self.fail(f"change_faction_reputation raised an exception with unknown faction ID: {e}")
+
+
+    def test_apply_rewards_faction_reputation(self):
+        quest_to_test = ALL_QUESTS.get(self.test_quest_id)
+        self.assertIsNotNone(quest_to_test, f"Quest {self.test_quest_id} not found in ALL_QUESTS.")
+
+        rewards_data = quest_to_test.rewards
+
+        # Ensure the target faction for the quest reward exists in player's reputations (or starts at 0)
+        target_faction_id_from_quest = rewards_data["faction_rep_changes"][0]["faction_id"]
+        amount_from_quest = rewards_data["faction_rep_changes"][0]["amount"]
+
+        # Check initial reputation for the target faction (should be 0 or not exist)
+        initial_rep = self.player.faction_reputations.get(target_faction_id_from_quest, 0)
+
+        self.player.apply_rewards(rewards_data, self.game_state)
+
+        expected_rep = initial_rep + amount_from_quest
+        # Clamp if necessary, though 25 shouldn't exceed limits from 0
+        expected_rep = max(-100, min(100, expected_rep))
+
+        self.assertEqual(self.player.faction_reputations.get(target_faction_id_from_quest), expected_rep)
+
+    def test_apply_rewards_multiple_faction_reputations(self):
+        rewards_data = {
+            'xp': 50,
+            'faction_rep_changes': [
+                {"faction_id": "wardens", "amount": 15},
+                {"faction_id": "hand", "amount": -10}
+            ]
+        }
+        initial_wardens_rep = self.player.faction_reputations.get("wardens", 0)
+        initial_hand_rep = self.player.faction_reputations.get("hand", 0)
+
+        self.player.apply_rewards(rewards_data, self.game_state)
+
+        self.assertEqual(self.player.faction_reputations.get("wardens"), initial_wardens_rep + 15)
+        self.assertEqual(self.player.faction_reputations.get("hand"), initial_hand_rep - 10)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces a complete Faction system, enabling players to interact with and build reputations with various in-game factions.

Key features and changes:

1.  **Faction Class (`factions.py`):**
    *   Defined a `Faction` class storing `id`, `name`, `description`, `goals`, `relationships` (with other factions), and `members` (key NPCs).

2.  **GameState Integration (`game_state.py`):**
    *   `GameState` now manages a dictionary of `Faction` objects (`self.factions`).
    *   Added `load_factions` method to `GameState` to populate factions from data files during initialization.
    *   `initialize_from_raw_data` calls `load_factions`.
    *   `config.py` updated to include `./data/Factions` in `RAG_DOCUMENT_SOURCES`.

3.  **Player Reputation (`game_state.py`):**
    *   `Player` class now has `faction_reputations` (dict mapping faction ID to score).
    *   `change_faction_reputation` method added to `Player` to modify reputation scores. This method:
        *   Clamps reputation between -100 and +100.
        *   Notifies the DM of changes (e.g., "플레이어의 [세력명] 평판이 [점수]만큼 변경되었습니다.").

4.  **Faction Data (`data/Factions/`):**
    *   Created JSON data files for three sample factions:
        *   `verdant_wardens.json`
        *   `crimson_hand.json`
        *   `merchants_guild.json`
    *   Each file includes core faction attributes and a `rag_data` field for detailed lore, history, and key figures, intended for RAG system use.

5.  **Quest Integration:**
    *   **Faction-Related Quest (`quests.py`):**
        *   Added a new quest "Whispers of Decay" (`q_verdant_wardens_aid`).
        *   Its reward structure includes a `faction_rep_changes` field (e.g., `[{"faction_id": "verdant_wardens", "amount": 25}]`) to specify reputation adjustments.
    *   **Reward Processing (`game_state.py`):**
        *   Modified `Player.apply_rewards` to process the `faction_rep_changes` key in quest rewards.
        *   It now calls `player.change_faction_reputation(faction_id, amount, game_state)` for each specified change.
        *   The `apply_rewards` signature was updated to accept `game_state`.

6.  **Unit Tests (`tests/test_factions.py`):**
    *   Added a comprehensive test suite covering:
        *   Faction object creation.
        *   Adding factions to `GameState`.
        *   Player reputation mechanics (initial state, changes, clamping).
        *   Robustness of DM messaging for unknown faction IDs.
        *   Correct application of faction reputation changes via quest rewards, including single and multiple faction adjustments.

This system allows your actions (like completing quests) to directly influence your standing with different world factions, adding depth to the gameplay experience.