### PR TITLE
Add new monsters and NPCs to enhance combat diversity.

### DIFF
--- a/data/NPCs/giant_spider.json
+++ b/data/NPCs/giant_spider.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "giant_spider",
+    "name": "Giant Spider",
+    "type": "monster",
+    "max_hp": 26,
+    "current_location": null,
+    "description": "A large, venomous spider. It moves quickly and can shoot webs to immobilize its prey.",
+    "combat_stats": {
+      "armor_class": 14,
+      "attack_bonus": 5,
+      "damage_bonus": 2,
+      "initiative_bonus": 3
+    },
+    "base_damage_dice": "1d8",
+    "special_abilities": [
+      {
+        "name": "Web Shot",
+        "description": "Ranged attack, DC 12 Dexterity saving throw or target is restrained."
+      }
+    ],
+    "vulnerabilities": ["fire"]
+  }
+]

--- a/data/NPCs/goblin_scout.json
+++ b/data/NPCs/goblin_scout.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "goblin_scout",
+    "name": "Goblin Scout",
+    "type": "monster",
+    "max_hp": 10,
+    "current_location": null,
+    "description": "A nimble goblin scout, good at hiding and ambushing.",
+    "combat_stats": {
+      "armor_class": 13,
+      "attack_bonus": 4,
+      "damage_bonus": 1,
+      "initiative_bonus": 2
+    },
+    "base_damage_dice": "1d6",
+    "special_abilities": [
+      {
+        "name": "Nimble Escape",
+        "description": "The goblin can take the Disengage or Hide action as a bonus action on each of its turns."
+      }
+    ],
+    "resistances": []
+  }
+]

--- a/data/NPCs/stone_golem.json
+++ b/data/NPCs/stone_golem.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "stone_golem",
+    "name": "Stone Golem",
+    "type": "monster",
+    "max_hp": 100,
+    "current_location": null,
+    "description": "A massive golem made of stone. It is slow but hits hard and is resistant to many forms of damage.",
+    "combat_stats": {
+      "armor_class": 17,
+      "attack_bonus": 7,
+      "damage_bonus": 5,
+      "initiative_bonus": -1
+    },
+    "base_damage_dice": "2d10",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "description": "The golem has advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "resistances": ["bludgeoning", "piercing", "slashing_from_nonmagical_weapons"],
+    "vulnerabilities": []
+  }
+]

--- a/data/Regions/ancient_kingdom_ruins.json
+++ b/data/Regions/ancient_kingdom_ruins.json
@@ -1,0 +1,12 @@
+{
+  "id": "ancient_kingdom_ruins",
+  "name": "Ancient Kingdom Ruins",
+  "description": "The crumbling remains of a once-great kingdom. Broken walls and overgrown paths hint at a forgotten history. A sense of ancient power and desolation hangs in the air.",
+  "exits": {
+    "north": "elderwood_forest",
+    "south": "ruined_courtyard"
+  },
+  "item_ids": [],
+  "npc_ids": ["stone_golem"],
+  "game_object_ids": ["ruined_archway", "weathered_statue"]
+}

--- a/data/Regions/gloomy_cave_entrance.json
+++ b/data/Regions/gloomy_cave_entrance.json
@@ -7,6 +7,6 @@
         "inward": "gloomy_cave_passage1"
     },
     "item_ids": ["iron_sword"],
-    "npc_ids": [],
+    "npc_ids": ["giant_spider"],
     "game_object_ids": []
 }

--- a/data/Regions/starter_town_square.json
+++ b/data/Regions/starter_town_square.json
@@ -9,6 +9,6 @@
         "west": "starter_town_west_road"
     },
     "item_ids": [],
-    "npc_ids": ["npc_town_guard_01", "npc_merchant_jane"],
+    "npc_ids": ["npc_town_guard_01", "npc_merchant_jane", "goblin_scout"],
     "game_object_ids": ["town_fountain"]
 }


### PR DESCRIPTION
This commit introduces three new types of adversaries:
- Giant Spider: A venomous creature with a web attack, found in caves.
- Goblin Scout: A nimble and stealthy ambusher, may appear near towns.
- Stone Golem: A resilient construct guarding ancient ruins, resistant to non-magical weapons.

New JSON data files for these NPCs have been added to `data/NPCs/`. They have been integrated into the game by adding their IDs to the `npc_ids` list of relevant locations:
- `giant_spider` added to `data/Regions/gloomy_cave_entrance.json`.
- `goblin_scout` added to `data/Regions/starter_town_square.json`.
- `stone_golem` added to the newly created `data/Regions/ancient_kingdom_ruins.json`.

The existing data-driven combat system and NPC loading mechanisms in `game_state.py` and `data_loader.py` support these additions without modification.