### PR TITLE
feat: Add monster component data structures and examples

### DIFF
--- a/config.py
+++ b/config.py
@@ -19,7 +19,10 @@ RAG_DOCUMENT_SOURCES = [
     './data/Factions',
     './data/Technology',
     './data/MagicSystems',
-    './data/Races'
+    './data/Races',
+    './data/RaceTemplates',
+    './data/AttributeTraits',
+    './data/RoleTemplates'
 ]
 
 # Fields to extract text from for RAG embedding.

--- a/data/AttributeTraits/attribute_traits.json
+++ b/data/AttributeTraits/attribute_traits.json
@@ -1,0 +1,101 @@
+[
+  {
+    "id": "swift",
+    "name_prefix_kr": "재빠른",
+    "description_fragment": "날렵한 움직임을 자랑하는",
+    "stat_modifiers": { "speed_add": 10, "ac_add": 1 },
+    "added_abilities": ["기습 공격 가능성"],
+    "added_resistances": [],
+    "added_vulnerabilities": []
+  },
+  {
+    "id": "tough",
+    "name_prefix_kr": "강인한",
+    "description_fragment": "쉽사리 쓰러지지 않는",
+    "stat_modifiers": { "hp_multiplier": 1.2, "ac_add": 1 },
+    "added_abilities": [],
+    "added_resistances": [],
+    "added_vulnerabilities": []
+  },
+  {
+    "id": "intelligent",
+    "name_prefix_kr": "지능적인",
+    "description_fragment": "교활한 전략을 사용하는",
+    "stat_modifiers": { "attack_bonus_add": 1 },
+    "added_abilities": ["전술적 움직임", "약점 간파 시도"],
+    "added_resistances": [],
+    "added_vulnerabilities": []
+  },
+  {
+    "id": "venomous",
+    "name_prefix_kr": "맹독의",
+    "description_fragment": "치명적인 독을 품은",
+    "stat_modifiers": {},
+    "added_abilities": ["독 공격 (추가 1d4 독 데미지, 내성 굴림 필요)"],
+    "added_resistances": ["poison"],
+    "added_vulnerabilities": []
+  },
+  {
+    "id": "fiery",
+    "name_prefix_kr": "화염의",
+    "description_fragment": "불타는 오라를 두른",
+    "stat_modifiers": {},
+    "added_abilities": ["화염 공격 (추가 1d6 화염 데미지)", "주변에 약한 화염 데미지"],
+    "added_resistances": ["fire"],
+    "added_vulnerabilities": ["cold"]
+  },
+  {
+    "id": "frost",
+    "name_prefix_kr": "얼어붙은",
+    "description_fragment": "냉기를 내뿜는",
+    "stat_modifiers": {},
+    "added_abilities": ["냉기 공격 (추가 1d6 냉기 데미지)", "느려짐 효과 부여 가능성"],
+    "added_resistances": ["cold"],
+    "added_vulnerabilities": ["fire"]
+  },
+  {
+    "id": "giant",
+    "name_prefix_kr": "거대한",
+    "description_fragment": "엄청난 크기를 자랑하는",
+    "stat_modifiers": { "hp_multiplier": 1.5, "damage_bonus_add": 2, "speed_add": -5 },
+    "added_abilities": ["광역 공격 (휘두르기)"],
+    "added_resistances": [],
+    "added_vulnerabilities": []
+  },
+  {
+    "id": "alpha",
+    "name_prefix_kr": "우두머리",
+    "description_fragment": "무리를 이끄는 강력한",
+    "stat_modifiers": { "hp_multiplier": 1.3, "attack_bonus_add": 1, "damage_bonus_add": 1 },
+    "added_abilities": ["무리에 명령 (아군 강화 또는 추가 행동 유도)"],
+    "added_resistances": [],
+    "added_vulnerabilities": []
+  },
+  {
+    "id": "elite",
+    "name_suffix_kr": "정예",
+    "description_fragment": "정예 훈련을 받은",
+    "stat_modifiers": { "hp_add": 20, "ac_add": 2, "attack_bonus_add": 1 },
+    "added_abilities": ["특수 기술 사용 (예: 반격)"],
+    "added_resistances": [],
+    "added_vulnerabilities": []
+  },
+  {
+    "id": "berserker",
+    "name_suffix_kr": "광전사",
+    "description_fragment": "분노에 찬",
+    "stat_modifiers": { "attack_bonus_add": 2, "ac_add": -2, "damage_bonus_add": 2},
+    "added_abilities": ["체력 낮을수록 공격력 증가", "무모한 공격"],
+    "added_resistances": [],
+    "added_vulnerabilities": []
+  },
+  {
+    "id": "armored",
+    "name_prefix_kr": "중무장한",
+    "description_fragment": "두꺼운 갑피로 덮인",
+    "stat_modifiers": { "ac_add": 3, "speed_add": -5 },
+    "added_abilities": [],
+    "added_resistances": ["piercing"],
+    "added_vulnerabilities": ["bludgeoning"]
+  }
+]

--- a/data/RaceTemplates/race_templates.json
+++ b/data/RaceTemplates/race_templates.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "orc",
+    "name_kr": "오크",
+    "description_base": "녹색 피부의 호전적인 종족인",
+    "base_combat_stats": {
+      "hp": 60,
+      "ac": 13,
+      "attack_bonus": 5,
+      "damage_dice": "1d12+3",
+      "speed": 30
+    },
+    "inherent_abilities": ["격노 가능성", "강인함"],
+    "possible_attribute_tags": ["strong", "armored", "berserker"],
+    "possible_role_tags": ["warrior", "brute"]
+  },
+  {
+    "id": "kobold",
+    "name_kr": "코볼트",
+    "description_base": "작고 교활한 파충류 인간인",
+    "base_combat_stats": {
+      "hp": 20,
+      "ac": 12,
+      "attack_bonus": 4,
+      "damage_dice": "1d6+2",
+      "speed": 30
+    },
+    "inherent_abilities": ["무리 전술", "빛에 민감함"],
+    "possible_attribute_tags": ["swift", "venomous", "sly"],
+    "possible_role_tags": ["scout", "archer", "trapper"]
+  },
+  {
+    "id": "skeleton",
+    "name_kr": "스켈레톤",
+    "description_base": "뼈만 남은 언데드인",
+    "base_combat_stats": {
+      "hp": 30,
+      "ac": 13,
+      "attack_bonus": 3,
+      "damage_dice": "1d8+1",
+      "speed": 30
+    },
+    "inherent_abilities": ["둔기에 약함", "독 및 상태이상 면역"],
+    "possible_attribute_tags": ["brittle", "ancient", "magic_resistant"],
+    "possible_role_tags": ["warrior", "archer", "guard"]
+  },
+  {
+    "id": "wolf",
+    "name_kr": "늑대",
+    "description_base": "사나운 육식 동물인",
+    "base_combat_stats": {
+      "hp": 35,
+      "ac": 13,
+      "attack_bonus": 5,
+      "damage_dice": "2d4+3",
+      "speed": 40
+    },
+    "inherent_abilities": ["무리 사냥", "뛰어난 후각"],
+    "possible_attribute_tags": ["alpha", "dire", "swift"],
+    "possible_role_tags": ["hunter", "pack_leader"]
+  },
+  {
+    "id": "spider",
+    "name_kr": "거미",
+    "description_base": "거대한 독 거미인",
+    "base_combat_stats": {
+      "hp": 25,
+      "ac": 14,
+      "attack_bonus": 4,
+      "damage_dice": "1d8+2",
+      "speed": 30,
+      "climb_speed": 30
+    },
+    "inherent_abilities": ["독 공격", "거미줄 보행"],
+    "possible_attribute_tags": ["giant", "venomous", "webspinner"],
+    "possible_role_tags": ["ambusher", "skulker"]
+  },
+  {
+    "id": "golem_stone",
+    "name_kr": "돌 골렘",
+    "description_base": "마법으로 움직이는 돌 구조물인",
+    "base_combat_stats": {
+      "hp": 100,
+      "ac": 17,
+      "attack_bonus": 7,
+      "damage_dice": "2d10+5",
+      "speed": 20
+    },
+    "inherent_abilities": ["마법 면역 (특정 주문 제외)", "구조물 특성", "둔기 공격에 취약"],
+    "possible_attribute_tags": ["ancient", "magic_resistant", "sturdy"],
+    "possible_role_tags": ["guardian", "juggernaut"]
+  }
+]

--- a/data/RoleTemplates/role_templates.json
+++ b/data/RoleTemplates/role_templates.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "warrior",
+    "name_kr": "전사",
+    "description_fragment": "근접 전투에 능숙한",
+    "stat_modifiers": { "attack_bonus_melee_add": 2, "hp_add": 10 },
+    "preferred_weapon_tags": ["sword", "axe", "mace"],
+    "abilities": ["강타 (추가 데미지 및 적 잠시 기절)", "방어 태세 (AC 증가)"]
+  },
+  {
+    "id": "archer",
+    "name_kr": "궁수",
+    "description_fragment": "원거리에서 화살을 쏘는",
+    "stat_modifiers": { "attack_bonus_ranged_add": 2, "perception_add": 2 },
+    "preferred_weapon_tags": ["bow", "crossbow"],
+    "abilities": ["정밀 사격 (명중률 증가)", "속사 (한 턴에 여러 발 발사, 데미지 감소)"]
+  },
+  {
+    "id": "shaman",
+    "name_kr": "주술사",
+    "description_fragment": "신비한 주술을 사용하는",
+    "stat_modifiers": { "magic_power_add": 2 },
+    "preferred_weapon_tags": ["staff", "totem", "wand"],
+    "abilities": ["치유 주문 (약)", "원소 공격 (작은 불꽃 또는 냉기 화살)", "저주 (적 약화)"]
+  },
+  {
+    "id": "scout",
+    "name_kr": "척후병",
+    "description_fragment": "은밀하게 움직이며 정찰하는",
+    "stat_modifiers": { "stealth_add": 3, "speed_add": 5 },
+    "preferred_weapon_tags": ["dagger", "short_sword", "sling"],
+    "abilities": ["숨기", "기습 공격 (숨은 상태에서 공격 시 추가 데미지)", "함정 발견"]
+  },
+  {
+    "id": "brute",
+    "name_kr": "투사",
+    "description_fragment": "강력한 힘으로 밀어붙이는",
+    "stat_modifiers": { "strength_add": 2, "hp_add": 15, "attack_bonus_melee_add": 1 },
+    "preferred_weapon_tags": ["club", "great_axe", "heavy_mace"],
+    "abilities": ["돌진 (적에게 달려들어 공격)", "내려치기 (강력한 단일 공격)"]
+  },
+  {
+    "id": "shield_bearer",
+    "name_kr": "방패병",
+    "description_fragment": "견고한 방패로 아군을 보호하는",
+    "stat_modifiers": { "ac_shield_bonus_add": 2, "constitution_add": 2 },
+    "preferred_weapon_tags": ["short_sword", "spear", "shield"],
+    "abilities": ["방패 올리기 (AC 일시적 대폭 증가)", "도발 (적의 공격을 자신에게 유도)", "보호 (인접 아군 AC 보너스)"]
+  },
+  {
+    "id": "assassin",
+    "name_kr": "암살자",
+    "description_fragment": "그림자 속에서 치명적인 일격을 날리는",
+    "stat_modifiers": { "dexterity_add": 2, "attack_bonus_add": 1, "crit_chance_add": 0.1 },
+    "preferred_weapon_tags": ["dagger", "rapier", "poisoned_weapon"],
+    "abilities": ["암살 (특정 조건 하 즉사 또는 막대한 데미지)", "은신 강화", "독 사용 전문가"]
+  }
+]

--- a/data_loader.py
+++ b/data_loader.py
@@ -183,6 +183,28 @@ if __name__ == '__main__':
             else:
                 print("First Item data was not a dictionary as expected.")
 
+        new_categories_to_check = ["RaceTemplates", "AttributeTraits", "RoleTemplates"]
+        for category in new_categories_to_check:
+            if category in raw_data_loaded and raw_data_loaded[category]:
+                print(f"\n--- Example: First loaded {category} raw data ---")
+                # Check if the data is a list (expected for these JSONs)
+                if isinstance(raw_data_loaded[category], list) and len(raw_data_loaded[category]) > 0:
+                    # The actual data for these categories is the list itself, where each item is a template.
+                    # The loader wraps this list inside another list. So raw_data_loaded[category][0] is the list of templates.
+                    first_item_list = raw_data_loaded[category][0]
+                    if isinstance(first_item_list, list) and len(first_item_list) > 0:
+                        first_item_data = first_item_list[0] # Get the first template from the list
+                        if isinstance(first_item_data, dict): # Should be a dict
+                            print(json.dumps(first_item_data, indent=2, ensure_ascii=False)) # ensure_ascii=False for Korean characters
+                        else:
+                            print(f"First {category} data item was not a dictionary as expected. Type: {type(first_item_data)}")
+                    else:
+                        print(f"{category} data content is not a list or is empty. Type: {type(first_item_list)}")
+                else:
+                    print(f"{category} data structure is not a list or is empty. Type: {type(raw_data_loaded[category])}")
+            else:
+                print(f"\n--- No data loaded for category: {category} ---")
+
     except ImportError:
         print("Could not import RAG_DOCUMENT_SOURCES from config.py. Make sure it's accessible.")
     except Exception as e:


### PR DESCRIPTION
This commit introduces the initial data structures and example JSON files for the combinable monster generation system.

New data files:
- `data/RaceTemplates/race_templates.json`: Defines monster races with base stats, abilities, and tags. Includes Orc, Kobold, Skeleton, Wolf, Spider, and Stone Golem.
- `data/AttributeTraits/attribute_traits.json`: Defines attributes/modifiers that can be applied to monsters, affecting stats and abilities. Includes Swift, Tough, Venomous, Fiery, etc.
- `data/RoleTemplates/role_templates.json`: Defines monster roles/classes with specific stat modifiers and abilities. Includes Warrior, Archer, Shaman, Scout, etc.

Configuration changes:
- `config.py`: Updated `RAG_DOCUMENT_SOURCES` to include the new data directories, making them available for the RAG system.

These components will be used by the `MonsterGenerator` (to be implemented) to create diverse and dynamic monsters. The data includes descriptive text for RAG system integration.